### PR TITLE
Correct variable name

### DIFF
--- a/mpc.odin
+++ b/mpc.odin
@@ -44,7 +44,7 @@ foreign lib {
 // mpc_result_t
 Result :: struct #raw_union {
 	error:   ^Error,
-	outpout: rawptr,
+	output: rawptr,
 }
 
 


### PR DESCRIPTION
The previous name of the attribute was `outpout`, so I corrected that.